### PR TITLE
Fix Redis connections after reconnect - consumer starts consuming the tasks after crash. 

### DIFF
--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -56,8 +56,8 @@ failover_strategies = {
     'shuffle': shufflecycle,
 }
 
-_log_connection = os.environ.get('KOMBU_LOG_CONNECTION', False)
-_log_channel = os.environ.get('KOMBU_LOG_CHANNEL', False)
+_log_connection = os.environ.get('KOMBU_LOG_CONNECTION', True)
+_log_channel = os.environ.get('KOMBU_LOG_CHANNEL', True)
 
 
 class Connection:

--- a/kombu/connection.py
+++ b/kombu/connection.py
@@ -56,8 +56,8 @@ failover_strategies = {
     'shuffle': shufflecycle,
 }
 
-_log_connection = os.environ.get('KOMBU_LOG_CONNECTION', True)
-_log_channel = os.environ.get('KOMBU_LOG_CHANNEL', True)
+_log_connection = os.environ.get('KOMBU_LOG_CONNECTION', False)
+_log_channel = os.environ.get('KOMBU_LOG_CHANNEL', False)
 
 
 class Connection:

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1204,7 +1204,7 @@ class Channel(virtual.Channel):
             class Connection(connection_cls):
                 def disconnect(self, *args):
                     super().disconnect(*args)
-                    # We only remove the connection from the poller
+                    # We remove the connection from the poller
                     # only if it has been added properly.
                     if channel._registered:
                         channel._on_connection_disconnect(self)

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -722,7 +722,7 @@ class Channel(virtual.Channel):
 
         if not self.ack_emulation:  # disable visibility timeout
             self.QoS = virtual.QoS
-
+        self._registered = False
         self._queue_cycle = cycle_by_name(self.queue_order_strategy)()
         self.Client = self._get_client()
         self.ResponseError = self._get_response_error()
@@ -747,6 +747,9 @@ class Channel(virtual.Channel):
             raise
 
         self.connection.cycle.add(self)  # add to channel poller.
+        # and set to true after sucessfuly added channel to the poll.
+        self._registered = True
+
         # copy errors, in case channel closed but threads still
         # are still waiting for data.
         self.connection_errors = self.connection.connection_errors
@@ -1201,7 +1204,9 @@ class Channel(virtual.Channel):
             class Connection(connection_cls):
                 def disconnect(self, *args):
                     super().disconnect(*args)
-                    channel._on_connection_disconnect(self)
+                    # We only remove the connection from the poller if it has been added properly
+                    if channel._registered:
+                        channel._on_connection_disconnect(self)
             connection_cls = Connection
 
         connparams['connection_class'] = connection_cls

--- a/kombu/transport/redis.py
+++ b/kombu/transport/redis.py
@@ -1204,7 +1204,8 @@ class Channel(virtual.Channel):
             class Connection(connection_cls):
                 def disconnect(self, *args):
                     super().disconnect(*args)
-                    # We only remove the connection from the poller if it has been added properly
+                    # We only remove the connection from the poller
+                    # only if it has been added properly.
                     if channel._registered:
                         channel._on_connection_disconnect(self)
             connection_cls = Connection


### PR DESCRIPTION
solution for the [discussion](https://github.com/celery/celery/discussions/7276) and [this issue](https://github.com/celery/celery/issues/8030) and [this issues as well](https://github.com/celery/kombu/pull/1734)

TODO: 
Write the history how it works and what was happened under the hood.. What caused real problem with those connections :) 